### PR TITLE
require( "./criticalCSS" ) should be require( "./criticalcss" )

### DIFF
--- a/lib/criticalrunner.js
+++ b/lib/criticalrunner.js
@@ -37,7 +37,7 @@ phantom args sent from critical.js:
 
 
 	var page = require( "webpage" ).create();
-	var cc = require( "./criticalCSS" );
+	var cc = require( "./criticalcss" );
 
 	phantom.onError = errorHandler;
 	page.onError = errorHandler;


### PR DESCRIPTION
OSX is forgiving towards case sensitivity, but Linux is not: require( "./criticalCss" ) should be require( "./criticalcss" ).
Could you also get this into the `grunt-criticalcss` task? Thanks!
