### PR TITLE
Fix for console output being added to CSS file

### DIFF
--- a/critical.js
+++ b/critical.js
@@ -122,7 +122,8 @@
 				width,
 				height,
 				JSON.stringify( forceInclude ),
-				tmpfile
+				tmpfile,
+				'-ignoreConole'
 			],
 			{
 				maxBuffer: bufferSize

--- a/lib/criticalrunner.js
+++ b/lib/criticalrunner.js
@@ -21,7 +21,7 @@ phantom args sent from critical.js:
 		height = phantom.args[2],
 		forceInclude = JSON.parse(phantom.args[3]),
 		rulesFile = phantom.args[4],
-		ingoreConsole = phantom.args.length >= 6 && phantom.args[5] === '-ignoreConole' ? true : false,
+		ingoreConsole = phantom.args.length >= 6 && phantom.args[5] === "-ignoreConole" ? true : false,
 		contents, rules;
 
 	var errorHandler = function(msg, trace) {

--- a/lib/criticalrunner.js
+++ b/lib/criticalrunner.js
@@ -21,6 +21,7 @@ phantom args sent from critical.js:
 		height = phantom.args[2],
 		forceInclude = JSON.parse(phantom.args[3]),
 		rulesFile = phantom.args[4],
+		ingoreConsole = phantom.args.length >= 6 && phantom.args[5] === '-ignoreConole' ? true : false,
 		contents, rules;
 
 	var errorHandler = function(msg, trace) {
@@ -42,8 +43,10 @@ phantom args sent from critical.js:
 	phantom.onError = errorHandler;
 	page.onError = errorHandler;
 	page.onConsoleMessage = function(msg) {
-		system.stdout.write( "Console output: " + msg );
-		system.stderr.write( "Console output error: " + msg );
+		if(!ingoreConsole){
+			system.stdout.write( "Console output: " + msg );
+			system.stderr.write( "Console output error: " + msg );
+		}
 	};
 
 

--- a/lib/criticalrunner.js
+++ b/lib/criticalrunner.js
@@ -80,7 +80,7 @@ phantom args sent from critical.js:
 						var elem = null;
 						// before testing the selector, we want to strip pseudo-elements out,
 						// because those selectors will not pass querySelector, yet we want them in criticalcss if they modify a critical selector
-						var selectorNoPsuedos = selector.replace( /\:+(before|after|first-w+|not\(\w+\))/gmi, "" );
+						var selectorNoPsuedos = selector.replace( /\:+(before|after|first-\w+|not\(\w+\))/gmi, "" );
 						try {
 							elem = window.document.querySelector( selectorNoPsuedos );
 						} catch (e){}

--- a/lib/criticalrunner.js
+++ b/lib/criticalrunner.js
@@ -80,7 +80,7 @@ phantom args sent from critical.js:
 						var elem = null;
 						// before testing the selector, we want to strip pseudo-elements out,
 						// because those selectors will not pass querySelector, yet we want them in criticalcss if they modify a critical selector
-						var selectorNoPsuedos = selector.replace( /\:+(before|after)/gmi, "" );
+						var selectorNoPsuedos = selector.replace( /\:+(before|after|first-w+|not\(\w+\))/gmi, "" );
 						try {
 							elem = window.document.querySelector( selectorNoPsuedos );
 						} catch (e){}


### PR DESCRIPTION
When running criticalCSS my CSS output included the console logs from my webpage.  I added an option in consoleRunner.js to suppress these from standard out.  I modified critical.js to pass this argument to critical runner.