### PR TITLE
fix: adding DOCTYPE to support casing in css

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.log
+.idea

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -126,6 +126,6 @@
 	};
 
 	var contents = fs.read( cssFile );
-	page.content = "<html><head><style>" + contents + "</style></head><body></body></html>";
+	page.content = "<!DOCTYPE html><html><head><style>" + contents + "</style></head><body></body></html>";
 
 }());

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "criticalcss",
   "description": "Finds the Above the Fold CSS for your page, and outputs it into a file",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "homepage": "https://github.com/filamentgroup/criticalcss",
   "author": {
     "name": "Scott Jehl/Jeffrey Lembeck/Filament Group",


### PR DESCRIPTION
This will fix #32. The issue is that when the styles are pulled via `window.document.styleSheets[0].cssRules` they will always be lower case unless the doctype is included in the html. So, this change is simply adding the DOCTYPE. With this change, this library now properly will capture css rule selectors with different casings.