### PR TITLE
Restore font faces

### DIFF
--- a/critical.js
+++ b/critical.js
@@ -271,4 +271,22 @@
 		return css.stringify(criticalAST, stringifyOpts);
 	};
 
+	exports.restoreFontFaces = function(originalCSS, criticalCSS, stringifyOpts){
+		// parse both the original CSS and the critical CSS so we can deal with the
+		// ASTs directly
+		var originalAST = css.parse(originalCSS);
+		var criticalAST = css.parse(criticalCSS);
+
+		var fontFaceRules = originalAST
+			.stylesheet
+			.rules
+			.filter(function(rule){
+				return rule.type === "font-face";
+			});
+
+		criticalAST.stylesheet.rules = fontFaceRules.concat(criticalAST.stylesheet.rules);
+
+		return css.stringify(criticalAST, stringifyOpts);
+	};
+
 }(typeof exports === "object" && exports || this));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "criticalcss",
   "description": "Finds the Above the Fold CSS for your page, and outputs it into a file",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "homepage": "https://github.com/filamentgroup/criticalcss",
   "author": {
     "name": "Scott Jehl/Jeffrey Lembeck/Filament Group",

--- a/test/files/font-face-critical.css
+++ b/test/files/font-face-critical.css
@@ -1,0 +1,1 @@
+.bio { color: red; }

--- a/test/files/font-face-expected.css
+++ b/test/files/font-face-expected.css
@@ -1,0 +1,6 @@
+@font-face {
+  font-family: "foo";
+  src: url("http://example.com/foo.ttf");
+}
+
+.bio { color: red; }

--- a/test/files/font-face.css
+++ b/test/files/font-face.css
@@ -1,0 +1,7 @@
+@font-face {
+  font-family: "foo";
+  src: url("http://example.com/foo.ttf");
+}
+
+.bio { color: red; }
+

--- a/test/unit/font_face_test.js
+++ b/test/unit/font_face_test.js
@@ -1,0 +1,35 @@
+/*global require:true*/
+(function( exports ){
+	"use strict";
+
+	var path = require("path");
+	var critical = require(path.join( "..", "..", "critical.js") );
+	var fs = require("fs");
+
+	function readTestCSSFile(name){
+		return fs
+			.readFileSync(path.join(__dirname, "..", "files", name + ".css"))
+			.toString();
+	}
+
+	function testDefs(test, opts) {
+		test.expect(1);
+
+		var result = critical
+					.restoreFontFaces(opts.original, opts.critical, { compress: true })
+					.replace(/\s/g, "");
+
+		test.equal(result, opts.expected.replace(/\s/g, ""));
+		test.done();
+	}
+
+	exports.fontFaceRules = {
+		"adds font-face back in": function(test) {
+			testDefs(test, {
+				original: readTestCSSFile("font-face"),
+				critical: readTestCSSFile("font-face-critical"),
+				expected: readTestCSSFile("font-face-expected")
+			});
+		}
+	};
+}(typeof exports === "object" && exports || this));


### PR DESCRIPTION
Do we need a check for `@font-face` rules in the critical css AST to prevent duplication of font declarations in the future if the CSS object model includes them? 