### PR TITLE
Critical font faces

### DIFF
--- a/critical.js
+++ b/critical.js
@@ -305,7 +305,7 @@
 				if(type === "rule") {
 					return acc.concat(collectFontFamilies(rule));
 				} else if (nested.indexOf(type) > -1){
-					return acc.concat(_.flatten(rule[type].rules.map(function(nestedRule){
+					return acc.concat(_.flatten(rule.rules.map(function(nestedRule){
 						return collectFontFamilies(nestedRule);
 					})));
 				} else {

--- a/critical.js
+++ b/critical.js
@@ -334,6 +334,10 @@
 			}));
 		}, []);
 
+		// the above reduce will include each font face for every appearence
+		// in a `font-family` declaration, here we remove duplicates
+		requiredFontFaces = _.uniq(requiredFontFaces);
+
 		// prepend the font faces to the critical css output
 		criticalAST.stylesheet.rules =
 			requiredFontFaces.concat(criticalAST.stylesheet.rules);

--- a/critical.js
+++ b/critical.js
@@ -271,4 +271,22 @@
 		return css.stringify(criticalAST, stringifyOpts);
 	};
 
+	exports.restoreFontFaces = function(originalCSS, criticalCSS, stringifyOpts){
+		// parse both the original CSS and the critical CSS so we can deal with the
+		// ASTs directly
+		var originalAST = css.parse(originalCSS);
+		var criticalAST = css.parse(criticalCSS);
+
+		var fontFaceRules = originalAST
+			.stylesheet
+			.rules
+			.filter(function(rule){
+				return rule.type === "font-face";
+			});
+
+		criticalAST.stylesheet.rules = fontFaceRules.concat(criticalAST.stylesheet.rules);
+
+		return css.stringify(criticalAST, stringifyOpts);
+	};
+
 }(typeof exports === "object" && exports || this));

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "criticalcss",
   "description": "Finds the Above the Fold CSS for your page, and outputs it into a file",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "homepage": "https://github.com/filamentgroup/criticalcss",
   "author": {
     "name": "Scott Jehl/Jeffrey Lembeck/Filament Group",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "criticalcss",
   "description": "Finds the Above the Fold CSS for your page, and outputs it into a file",
-  "version": "2.1.0",
+  "version": "2.0.0",
   "homepage": "https://github.com/filamentgroup/criticalcss",
   "author": {
     "name": "Scott Jehl/Jeffrey Lembeck/Filament Group",

--- a/test/files/font-face-critical.css
+++ b/test/files/font-face-critical.css
@@ -1,3 +1,6 @@
 .bio { font-family: foo; }
-.test { font-family: "bar baz bing"; }
-.test2 { font-family: "bar baz bing"; }
+
+@media (min-width: 900px) {
+  .test { font-family: "bar baz bing"; }
+  .test2 { font-family: "bar baz bing"; }
+}

--- a/test/files/font-face-critical.css
+++ b/test/files/font-face-critical.css
@@ -1,0 +1,1 @@
+.bio { color: red; }

--- a/test/files/font-face-critical.css
+++ b/test/files/font-face-critical.css
@@ -1,1 +1,1 @@
-.bio { color: red; }
+.bio { color: red; font-family: foo; }

--- a/test/files/font-face-critical.css
+++ b/test/files/font-face-critical.css
@@ -1,1 +1,2 @@
-.bio { color: red; font-family: foo; }
+.bio { font-family: foo; }
+.test { font-family: "bar baz bing"; }

--- a/test/files/font-face-critical.css
+++ b/test/files/font-face-critical.css
@@ -1,2 +1,3 @@
 .bio { font-family: foo; }
 .test { font-family: "bar baz bing"; }
+.test2 { font-family: "bar baz bing"; }

--- a/test/files/font-face-expected.css
+++ b/test/files/font-face-expected.css
@@ -1,0 +1,6 @@
+@font-face {
+  font-family: "foo";
+  src: url("http://example.com/foo.ttf");
+}
+
+.bio { color: red; }

--- a/test/files/font-face-expected.css
+++ b/test/files/font-face-expected.css
@@ -9,5 +9,7 @@
 }
 
 .bio { font-family: foo; }
-.test { font-family: "bar baz bing"; }
-.test2 { font-family: "bar baz bing"; }
+@media (min-width: 900px) {
+  .test { font-family: "bar baz bing"; }
+  .test2 { font-family: "bar baz bing"; }
+}

--- a/test/files/font-face-expected.css
+++ b/test/files/font-face-expected.css
@@ -10,3 +10,4 @@
 
 .bio { font-family: foo; }
 .test { font-family: "bar baz bing"; }
+.test2 { font-family: "bar baz bing"; }

--- a/test/files/font-face-expected.css
+++ b/test/files/font-face-expected.css
@@ -3,4 +3,10 @@
   src: url("http://example.com/foo.ttf");
 }
 
-.bio { color: red; font-family: foo; }
+@font-face {
+  font-family: "bar baz bing";
+  src: url("http://example.com/bar-baz-bing.ttf");
+}
+
+.bio { font-family: foo; }
+.test { font-family: "bar baz bing"; }

--- a/test/files/font-face-expected.css
+++ b/test/files/font-face-expected.css
@@ -3,4 +3,4 @@
   src: url("http://example.com/foo.ttf");
 }
 
-.bio { color: red; }
+.bio { color: red; font-family: foo; }

--- a/test/files/font-face.css
+++ b/test/files/font-face.css
@@ -3,5 +3,5 @@
   src: url("http://example.com/foo.ttf");
 }
 
-.bio { color: red; }
+.bio { color: red; font-family: foo; }
 

--- a/test/files/font-face.css
+++ b/test/files/font-face.css
@@ -3,5 +3,15 @@
   src: url("http://example.com/foo.ttf");
 }
 
+@font-face {
+  font-family: "bar baz bing";
+  src: url("http://example.com/bar-baz-bing.ttf");
+}
+
+@font-face {
+  font-family: "bak";
+  src: url("http://example.com/bak.ttf");
+}
+
 .bio { color: red; font-family: foo; }
 

--- a/test/files/font-face.css
+++ b/test/files/font-face.css
@@ -15,3 +15,8 @@
 
 .bio { color: red; font-family: foo; }
 
+@media (min-width: 900px) {
+  .test { font-family: "bar baz bing"; }
+  .test2 { font-family: "bar baz bing"; }
+}
+

--- a/test/files/font-face.css
+++ b/test/files/font-face.css
@@ -1,0 +1,7 @@
+@font-face {
+  font-family: "foo";
+  src: url("http://example.com/foo.ttf");
+}
+
+.bio { color: red; }
+

--- a/test/unit/font_face_test.js
+++ b/test/unit/font_face_test.js
@@ -1,0 +1,35 @@
+/*global require:true*/
+(function( exports ){
+	"use strict";
+
+	var path = require("path");
+	var critical = require(path.join( "..", "..", "critical.js") );
+	var fs = require("fs");
+
+	function readTestCSSFile(name){
+		return fs
+			.readFileSync(path.join(__dirname, "..", "files", name + ".css"))
+			.toString();
+	}
+
+	function testDefs(test, opts) {
+		test.expect(1);
+
+		var result = critical
+					.restoreFontFaces(opts.original, opts.critical, { compress: true })
+					.replace(/\s/g, "");
+
+		test.equal(result, opts.expected.replace(/\s/g, ""));
+		test.done();
+	}
+
+	exports.fontFaceRules = {
+		"adds font-face back in": function(test) {
+			testDefs(test, {
+				original: readTestCSSFile("font-face"),
+				critical: readTestCSSFile("font-face-critical"),
+				expected: readTestCSSFile("font-face-expected")
+			});
+		}
+	};
+}(typeof exports === "object" && exports || this));


### PR DESCRIPTION
In contrast to #51 this selects only those font faces that appear in a `font-family` declaration in the critical css rules, `@media`, `@supports`, and `@document` rules.

@zachleat @scottjehl can you add some of the corner case tests in a comment. I'll add them to the test file. As it is you can see the example with the font family `foo` in `font-face.css`, `font-face-critical.css` and `font-face-expected.css`. 